### PR TITLE
Third party privacy policy link

### DIFF
--- a/docs/privacypolicy.md
+++ b/docs/privacypolicy.md
@@ -7,7 +7,7 @@ the service, or send you news or information, in which case we will give
 you the option to sign off from those updates. We will not sell your
 email address to third parties.
 
-Payments are handled by FastSpring. Be sure to read their Privacy
-Policy.
+Payments are handled by FastSpring. Be sure to read [their Privacy
+Policy](https://fastspring.com/privacy/).
 
 Be sure to read the Privacy Policy of any apps you install.


### PR DESCRIPTION
Save your users the effort of having to find their website and then find their privacy link. ;) I chose to include "their" in the link to make it really obvious the destination privacy policy is not yours.